### PR TITLE
feat: Revert policy engine feature flag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,5 @@ module "helm_release" {
   global_static_ip_name = google_compute_global_address.this.name
   pre_shared_cert       = google_compute_managed_ssl_certificate.this.name
 
-  enable_new_policy_engine = var.enable_new_policy_engine
-
   depends_on = [module.gke, module.database, module.redis, module.service_accounts]
 }

--- a/modules/helm_release/main.tf
+++ b/modules/helm_release/main.tf
@@ -30,8 +30,6 @@ locals {
         password = var.redis_password,
         port     = tostring(var.redis_port),
       },
-
-      enableNewPolicyEngine = var.enable_new_policy_engine,
     },
 
     webservice   = { image = { tag = "8264bfc" } },

--- a/modules/helm_release/variables.tf
+++ b/modules/helm_release/variables.tf
@@ -94,8 +94,3 @@ variable "values" {
   type    = any
   default = {}
 }
-
-variable "enable_new_policy_engine" {
-  type    = bool
-  default = false
-}

--- a/variables.tf
+++ b/variables.tf
@@ -93,8 +93,3 @@ variable "deploy_helm_release" {
   type    = bool
   default = true
 }
-
-variable "enable_new_policy_engine" {
-  type    = bool
-  default = false
-}


### PR DESCRIPTION
Reverts ctrlplanedev/terraform-google-ctrlplane#11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the option to configure the "enable_new_policy_engine" setting from the deployment configuration. This setting is no longer available for customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->